### PR TITLE
Update Incident Endpoint with Custom Success and Error Responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from time import time
 from translate import translate_incidents, clean_unused_translation
 
 import google.oauth2.id_token
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, jsonify
 from flask_cors import CORS
 from google.auth.transport import Response, requests
 
@@ -128,12 +128,19 @@ def delete_incident(incident_id):
 
 @app.route("/incidents", methods=["POST"])
 def create_incident():
-    #_check_is_admin(request)
-    req = request.get_json().get("incident")
-    if req is None:
-        raise ValueError("Missing incident")
-    id = insertIncident(req)
-    return {"incident_id": id}
+    try:
+        # _check_is_admin(request)
+        req = request.get_json().get("incident")
+        if req is None:
+            return jsonify({"error": "Invalid request data or internal server error."}), 400
+        id = insertIncident(req)
+        return jsonify({
+            "message": "Incident reported successfully.",
+            "user_report_id": str(id)
+        }), 201
+    except Exception as e:
+        # log the exception e if needed
+        return jsonify({"error": "Invalid request data or internal server error."}), 500
 
 
 def _aggregate_monthly_total(fullmonth_stats, state):
@@ -249,7 +256,7 @@ if __name__ == "__main__":
     # http://flask.pocoo.org/docs/1.0/quickstart/#static-files. Once deployed,
     # App Engine itself will serve those files as configured in app.yaml.
 
-    app.run(host="0.0.0.0", port=8083, debug=True)
+    app.run(host="192.168.1.161", port=8082, debug=True)
 
     #app.run(host="192.168.0.18", port=8082, debug=True)
     # app.run(host="0.0.0.0", port=8082, debug=True)


### PR DESCRIPTION
**Description:** 

This PR updates the /incidents POST endpoint to improve the response format for both successful and failed requests. The changes include:

- On successful incident creation (HTTP 201), the response will return:
{
  "message": "Incident reported successfully.",
  "user_report_id": "string"
}

- On failure (HTTP 400 Bad Request or 500 Internal Server Error), the response will return:
{
  "error": "Invalid request data or internal server error."
}

**Changes:**

- Modified the response body to include a custom message and user report ID on success.
- Added standardized error handling for bad requests and internal server errors.

**Testing:**

- Ensure that a valid incident request returns the expected 201 response.
- Test invalid requests to confirm that they return appropriate error messages with status codes 400 or 500.

![image](https://github.com/user-attachments/assets/3e80815e-9f1d-4ca0-81e3-f3fcc5f63a5f)

<img width="721" alt="image" src="https://github.com/user-attachments/assets/21b93c0a-1de4-4dad-bc16-1d483191f42d">

![image](https://github.com/user-attachments/assets/b1511a8b-5b57-4609-ad41-9d17fb526751)
