### PR TITLE
Implement the get incident(report) by id, API & DB function

### DIFF
--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -291,3 +291,23 @@ def getAllIncidents(params, user_role):
         },
         "incidents": incidents
     }
+    
+def get_incident_by_id(report_id):
+    try:
+        # Initialize Firestore client
+        db = firestore.Client()
+
+        # Get document reference and attempt to fetch
+        doc_ref = db.collection('incident').document(report_id)
+        doc = doc_ref.get()
+        
+        # Check if document exists
+        if not doc.exists:
+            return {"error": "Report ID not found", "report_id": report_id}, 404
+            
+        # Return successful response
+        return doc.to_dict(), 200
+        
+    except Exception as e:
+        print(f"Error getting incident by ID: {str(e)}")  # Log the error
+        return {"error": "Failed to get incident", "details": str(e)}, 500

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -295,17 +295,11 @@ def getAllIncidents(params, user_role):
 def get_incident_by_id(report_id):
     try:
         db = firestore.Client()
-
         doc_ref = db.collection('incident').document(report_id)
         doc = doc_ref.get()
-        
-
         if not doc.exists:
             return {"error": "Report ID not found", "report_id": report_id}, 404
-            
-
         return doc.to_dict(), 200
-        
     except Exception as e:
         print(f"Error getting incident by ID: {str(e)}") 
         return {"error": "Failed to get incident", "details": str(e)}, 500

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -294,20 +294,18 @@ def getAllIncidents(params, user_role):
     
 def get_incident_by_id(report_id):
     try:
-        # Initialize Firestore client
         db = firestore.Client()
 
-        # Get document reference and attempt to fetch
         doc_ref = db.collection('incident').document(report_id)
         doc = doc_ref.get()
         
-        # Check if document exists
+
         if not doc.exists:
             return {"error": "Report ID not found", "report_id": report_id}, 404
             
-        # Return successful response
+
         return doc.to_dict(), 200
         
     except Exception as e:
-        print(f"Error getting incident by ID: {str(e)}")  # Log the error
+        print(f"Error getting incident by ID: {str(e)}") 
         return {"error": "Failed to get incident", "details": str(e)}, 500

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ from google.auth.transport import Response, requests
 
 import firestore.admins
 from common import User
-from firestore.incidents import deleteIncident, getIncidents, getStats, insertIncident, getUserReports, insertUserReport, updateUserReport
+from firestore.incidents import deleteIncident, getIncidents, getStats, insertIncident, getUserReports, insertUserReport, updateUserReport, get_incident_by_id
 from firestore.tokens import add_token
 import incident_publisher
 
@@ -264,6 +264,17 @@ def update_user_report():
     # Call the updateUserReport function and get the response and status code
     response, code = updateUserReport(data)
     return response, code
+
+
+@app.route('/incidents/<report_id>', methods=['GET'])
+def get_incident(report_id):
+    try:
+        _check_is_admin(request)
+        response, code = get_incident_by_id(report_id)
+        return jsonify(response), code
+    except Exception as e:
+        print(f"Error in get_incident endpoint: {str(e)}")
+        return jsonify({"error": "Internal server error"}), 500
 
 if __name__ == "__main__":
     # This is used when running locally only. When deploying to Google App

--- a/main.py
+++ b/main.py
@@ -270,10 +270,8 @@ def update_user_report():
 def get_incident(report_id):
     try:
         _check_is_admin(request)
-        
         response, code = get_incident_by_id(report_id)
         return jsonify(response), code
-    
     except Exception as e:
         print(f"Error in get_incident endpoint: {str(e)}")
         return jsonify({"error": "Internal server error"}), 500

--- a/main.py
+++ b/main.py
@@ -133,10 +133,10 @@ def get_user_reports():
     }
 
 
-@app.route("/incidents/<incident_id>", methods=["DELETE"])
-def delete_incident(incident_id):
+@app.route("/incidents/<id>", methods=["DELETE"])
+def delete_incident(id):
     _check_is_admin(request)
-    deleteIncident(incident_id)
+    deleteIncident(id)
     return {"status": "success"}
 
 
@@ -266,11 +266,11 @@ def update_user_report():
     return response, code
 
 # Admin-only endpoint to view user reported incident details that may including private contact information
-@app.route('/incidents/<report_id>', methods=['GET'])
-def get_incident(report_id):
+@app.route('/incidents/<id>', methods=['GET'])
+def get_incident(id):
     try:
         _check_is_admin(request)
-        response, code = get_incident_by_id(report_id)
+        response, code = get_incident_by_id(id)
         return jsonify(response), code
     except Exception as e:
         print(f"Error in get_incident endpoint: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -265,7 +265,7 @@ def update_user_report():
     response, code = updateUserReport(data)
     return response, code
 
-
+# Admin-only endpoint to view user reported incident details that may including private contact information
 @app.route('/incidents/<report_id>', methods=['GET'])
 def get_incident(report_id):
     try:

--- a/main.py
+++ b/main.py
@@ -270,8 +270,10 @@ def update_user_report():
 def get_incident(report_id):
     try:
         _check_is_admin(request)
+        
         response, code = get_incident_by_id(report_id)
         return jsonify(response), code
+    
     except Exception as e:
         print(f"Error in get_incident endpoint: {str(e)}")
         return jsonify({"error": "Internal server error"}), 500


### PR DESCRIPTION
**Goal of the PR**:
This API is used by **Admin** to view the details of user-reported incidents

**Context**:

- We ask users to optionally update their contact information after reporting incidents, so to protect their privacy, only admin can view a user report's details
- It's different than a general get incident by id and we don't have a usage for now. (Our frontend shows incident details in a modal using pre-fetched data from get all incidents API)

**Changes made**:
• Function for database:
[add a function that gets an incident from the DB](https://github.com/1thing-org/hatecrimetracker/commit/832655b42e1501a452d686e711b5233e88b5389b)
• API endpoint:
[add get incident(report) by id API endpoint](https://github.com/1thing-org/hatecrimetracker/commit/24be07cfb1e29573e55fda6df94bfd48ffef385d)

**Tested with Postman**:
• Got the incident by id successfully with admin check commented out:
![Success ](https://github.com/user-attachments/assets/de122cb4-2499-4bda-93e6-eaf3d9b6cd90)
• Tested admin check:
![No permission admin](https://github.com/user-attachments/assets/6dc28859-4bc0-41d1-8950-8162a4933a3c)
• Tested if the id doesn't exist:
![doesn't exist](https://github.com/user-attachments/assets/5987f840-ca4d-476b-bf8b-fcd9842b7a78)

**Question**:
Should we standardize where each type of error is handled (API vs Function)? And is it necessary for us to add more specific error types like FirestoreError, etc.

Context: I noticed our error handling is distributed between function and API layers, and we're using generic Exception catches. 

