### PR TITLE
fix stats fetching issue by setting higher default pagination

### DIFF
--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -54,7 +54,7 @@ VALID_SELF_REPORT_STATUSES = {"all", "approved", "rejected", "new"}
 VALID_TYPE_STATUSES = {"news", "self_report", "both"}
 
 @cached(cache=INCIDENT_CACHE)
-def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size="1000"):
+def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size=""):
     # Convert start_row and page_size to integers
     # TODO: implement the pagination based on Firestore (https://firebase.google.com/docs/firestore/query-data/query-cursors)
     try:
@@ -64,7 +64,7 @@ def queryIncidents(start: datetime, end: datetime, state="", type="", self_repor
         if type not in VALID_TYPE_STATUSES:
             return {"error": f"Invalid type: {type}. Allowed values are {VALID_TYPE_STATUSES}"}
         start_row = int(start_row) if str(start_row).isdigit() and int(start_row) >= 0 else 0
-        page_size = int(page_size) if str(page_size).isdigit() and int(page_size) > 0 else 10
+        page_size = int(page_size) if str(page_size).isdigit() and int(page_size) > 0 else 1000
     except ValueError:
         start_row, page_size = 0, 10  # Default values
     

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -54,7 +54,7 @@ VALID_SELF_REPORT_STATUSES = {"all", "approved", "rejected", "new"}
 VALID_TYPE_STATUSES = {"news", "self_report", "both"}
 
 @cached(cache=INCIDENT_CACHE)
-def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size=""):
+def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size="1000"):
     # Convert start_row and page_size to integers
     # TODO: implement the pagination based on Firestore (https://firebase.google.com/docs/firestore/query-data/query-cursors)
     try:


### PR DESCRIPTION
**Goal of the PR**:
Fix the `stats api` fetching issue, the `stats` function doesn't need pagination, but it replies on `queryIncidents` function, so need to set the default size higher so that the stats api could fetching correctly.
![image](https://github.com/user-attachments/assets/56598cdc-5388-4a9a-bd03-69a8b9421759)
![image](https://github.com/user-attachments/assets/eade8ed2-e40e-45ce-8f33-5bf35f7e54aa)
