### PR TITLE
support dynamically choose which DB collection to use

### DIFF
--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -60,7 +60,7 @@ VALID_SELF_REPORT_STATUSES = {"all", "approved", "rejected", "new"}
 VALID_TYPE_STATUSES = {"news", "self_report", "both"}
 
 @cached(cache=INCIDENT_CACHE)
-def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size="", use_cache=False):
+def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size=""):
     # Convert start_row and page_size to integers
     # TODO: implement the pagination based on Firestore (https://firebase.google.com/docs/firestore/query-data/query-cursors)
     try:

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -36,7 +36,9 @@ class UserReport(BaseReport):
     email = mdl.TextField(required=False)
     phone = mdl.TextField(required=False)
     class Meta:
-        collection_name = "incident"  # Force this class to use the "incident" collection
+        # If you want to use a different collection:
+        # Before running the app, set with: export FIRESTORE_COLLECTION=your_test_collection
+        collection_name = os.getenv('FIRESTORE_COLLECTION', 'incident')  # Default to 'incident'
 
 
 class Incident(BaseReport):

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -39,6 +39,7 @@ class UserReport(BaseReport):
     class Meta:
         # If you want to use a different collection:
         # Before running the app, set with: export FIRESTORE_COLLECTION=your_test_collection
+        # If running with run.sh, the collection name is set in the run.sh script
         collection_name = os.getenv('FIRESTORE_COLLECTION', 'incident')  # Default to 'incident'
 
 
@@ -339,3 +340,15 @@ def get_incident_by_id(report_id):
     except Exception as e:
         print(f"Error getting incident by ID: {str(e)}") 
         return {"error": "Failed to get incident", "details": str(e)}, 500
+
+# Log for checking the firesotre colection name in use
+def verify_collection():
+    collection_name = os.getenv('FIRESTORE_COLLECTION', 'incident')
+    print(f"Using collection: {collection_name}")
+    # Example query to verify
+    db = firestore.Client()
+    docs = db.collection(collection_name).limit(1).stream()
+    for doc in docs:
+        print(f"Document in collection: {doc.id}")
+
+verify_collection()

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -52,13 +52,15 @@ class Incident(BaseReport):
     title = mdl.TextField(required=False)
     title_translate = mdl.MapField(required=False)
     parent_doc = mdl.TextField(column_name="parent")
+    class Meta:
+        collection_name = os.getenv('FIRESTORE_COLLECTION', 'incident')
 
 
 VALID_SELF_REPORT_STATUSES = {"all", "approved", "rejected", "new"}
 VALID_TYPE_STATUSES = {"news", "self_report", "both"}
 
 @cached(cache=INCIDENT_CACHE)
-def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size=""):
+def queryIncidents(start: datetime, end: datetime, state="", type="", self_report_status="", start_row="", page_size="", use_cache=False):
     # Convert start_row and page_size to integers
     # TODO: implement the pagination based on Firestore (https://firebase.google.com/docs/firestore/query-data/query-cursors)
     try:

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 
 import dateparser

--- a/run.sh
+++ b/run.sh
@@ -3,5 +3,7 @@ python3.9 -m venv env
 source env/bin/activate
 pip install --upgrade pip
 pip install  -r requirements.txt
+# The default Firestore collection is incident, to use a different collection:
+# export FIRESTORE_COLLECTION=collection_name
 export GOOGLE_APPLICATION_CREDENTIALS=./hate-crime-tracker-7d52738f7212.json
 python main.py


### PR DESCRIPTION
**Goal of the PR**:
- Add scripts for setting a different Firestore collection. 
- Add log to verify which collection is in use 

Note: If you set collection name in incident, it will not work if you are running the backend with **./run.sh**, it needs to be set in the `run.sh` script, see **line 6 -7**:
```Python
# The default Firestore collection is incident, to use a different collection:
export FIRESTORE_COLLECTION=collection_name
```

**Tested with Log**:

![image](https://github.com/user-attachments/assets/37887b0f-0a63-4335-aa33-5e33fd22e2e6)

**Tested with Postman**:
Set the collection to:
```Python
export FIRESTORE_COLLECTION=incident-refined
```
![Screenshot 2025-03-13 at 12 33 58 PM](https://github.com/user-attachments/assets/ae1c3f74-7cb5-4727-b0b7-6edb19f6f4b8)
If not refined:
![Screenshot 2025-03-13 at 12 34 36 PM](https://github.com/user-attachments/assets/b1a675bf-5a14-49e7-9ad6-bcfdb421e8d9)
![Screenshot 2025-03-13 at 12 35 09 PM](https://github.com/user-attachments/assets/5d61d80e-ee1f-4fa7-b73d-ee33a7ad536d)

