### PR TITLE
Fix Backward Compatibility Issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -229,14 +229,49 @@ def get_stats():
             aggregated[str_date]["news"] += stat["news"]
             aggregated[str_date]["self_report"] += stat["self_report"]
 
-    # Convert aggregated to the format expected by frontend, since it's already an object, I kept the value for backward compatibility
-    stats = [{"key": k, "value": v["news"] + v["self_report"], "news": v["news"], "self_report": v["self_report"]} for k, v in sorted(aggregated.items(), reverse=True)]
+    # Convert aggregated to the format expected by production - just key and value for backward compatibility
+    stats = [{"key": k, "value": v["news"] + v["self_report"]} for k, v in sorted(aggregated.items(), reverse=True)]
 
     # Create monthly breakdown (detailed objects) and monthly stats (simple numbers for backward compatibility)
     monthly_breakdown = monthly_stats  # Keep the detailed object structure
     monthly_stats = {k: v["news"] + v["self_report"] for k, v in monthly_breakdown.items()}  # Convert to simple numbers
 
-    return {"stats": stats, "total": total, "monthly_stats": monthly_stats, "monthly_breakdown": monthly_breakdown, "insight": insight}
+    # NEW EXTENSIBLE FIELDS - {Key : structure}
+    # daily_statistics: key = date (e.g. "2023-01-17")
+    daily_statistics = {}
+    for date_key, counts in aggregated.items():
+        daily_statistics[date_key] = {
+            "news": counts["news"], 
+            "self_report": counts["self_report"]
+        }
+    
+    # monthly_statistics: key = month (e.g. "2022-05") 
+    monthly_statistics = {}
+    for month, breakdown in monthly_breakdown.items():
+        monthly_statistics[month] = {
+            "news": breakdown["news"],
+            "self_report": breakdown["self_report"]
+        }
+    
+    # insights: key = location (e.g. "CA")
+    insights = {}
+    for location, breakdown in insight.items():
+        insights[location] = {
+            "news": breakdown["news"],
+            "self_report": breakdown["self_report"]
+        }
+
+    return {
+        # EXISTING FIELDS - Keep for production backward compatibility
+        "stats": stats, 
+        "total": total, 
+        "monthly_stats": monthly_stats,
+        
+        # NEW EXTENSIBLE FIELDS - For new self-report feature
+        "daily_statistics": daily_statistics,
+        "monthly_statistics": monthly_statistics,
+        "insights": insights
+    }
 
 
 @app.route("/publish_incidents")

--- a/main.py
+++ b/main.py
@@ -232,7 +232,11 @@ def get_stats():
     # Convert aggregated to the format expected by frontend, since it's already an object, I kept the value for backward compatibility
     stats = [{"key": k, "value": v["news"] + v["self_report"], "news": v["news"], "self_report": v["self_report"]} for k, v in aggregated.items()]
 
-    return {"stats": stats, "total": total, "monthly_stats": monthly_stats, "insight": insight}
+    # Create monthly breakdown (detailed objects) and monthly stats (simple numbers for backward compatibility)
+    monthly_breakdown = monthly_stats  # Keep the detailed object structure
+    monthly_stats = {k: v["news"] + v["self_report"] for k, v in monthly_breakdown.items()}  # Convert to simple numbers
+
+    return {"stats": stats, "total": total, "monthly_stats": monthly_stats, "monthly_breakdown": monthly_breakdown, "insight": insight}
 
 
 @app.route("/publish_incidents")

--- a/main.py
+++ b/main.py
@@ -179,7 +179,7 @@ def _aggregate_monthly_total(stats, state=None):
 @app.route("/stats")
 def get_stats():
     # return
-    # stats: [{"key": date, "news": count, "self_report": count}] this is daily count filtered by state if needed
+    # stats: [{"key": date, "value": count, "news": count, "self_report": count}] this is daily count filtered by state if needed
     # total: { "location": count } : total per state, not filtered by state
     # insight: { "location": {"news": count, "self_report": count} } : breakdown by type
     start_date, end_date, state, type, self_report_status, _, _ = _getCommonArgs()
@@ -229,8 +229,8 @@ def get_stats():
             aggregated[str_date]["news"] += stat["news"]
             aggregated[str_date]["self_report"] += stat["self_report"]
 
-    # Convert aggregated to the format expected by frontend
-    stats = [{"key": k, "news": v["news"], "self_report": v["self_report"]} for k, v in aggregated.items()]
+    # Convert aggregated to the format expected by frontend, since it's already an object, I kept the value for backward compatibility
+    stats = [{"key": k, "value": v["news"] + v["self_report"], "news": v["news"], "self_report": v["self_report"]} for k, v in aggregated.items()]
 
     return {"stats": stats, "total": total, "monthly_stats": monthly_stats, "insight": insight}
 

--- a/main.py
+++ b/main.py
@@ -230,7 +230,7 @@ def get_stats():
             aggregated[str_date]["self_report"] += stat["self_report"]
 
     # Convert aggregated to the format expected by frontend, since it's already an object, I kept the value for backward compatibility
-    stats = [{"key": k, "value": v["news"] + v["self_report"], "news": v["news"], "self_report": v["self_report"]} for k, v in aggregated.items()]
+    stats = [{"key": k, "value": v["news"] + v["self_report"], "news": v["news"], "self_report": v["self_report"]} for k, v in sorted(aggregated.items(), reverse=True)]
 
     # Create monthly breakdown (detailed objects) and monthly stats (simple numbers for backward compatibility)
     monthly_breakdown = monthly_stats  # Keep the detailed object structure


### PR DESCRIPTION
### **Updated: New Fields added, Old Fields keep the Same with Production**
Production fields: `stats`, `total`, `monthly_stats`
New fields: `daily_statistics`, `monthly_statistics`, `insights` (Need to change new web/mobile frontend accordingly) 

![Screenshot 2025-06-23 at 4 33 23 PM](https://github.com/user-attachments/assets/1c734823-0ecd-414e-8d7b-f11b74b54098)



### **Previous Changes:**

1. Fixed backward compatibility
2. Fixed the daily returning from ascending to descending 
### **Before Fix:**
The main branch returns:
<img width="860" alt="Screenshot 2025-06-20 at 4 46 07 PM" src="https://github.com/user-attachments/assets/7162825a-e5d6-4bc6-a6bd-753dc0f541a1" />
The feature branch returns:
<img width="947" alt="Screenshot 2025-06-20 at 4 46 34 PM" src="https://github.com/user-attachments/assets/7c1b3f85-2eda-4124-973c-e1e9c4642932" />

### **Fixed Returns:**
No need to worry about `insight` (new field) and `total` (no change).
-`stats`: since it's already an object, simply added `value` back (searched and says it's a good practice)
-`monthly_stats`: change it back to the original
-`monthly_breakdown`: new field for the new feature frontend (need to change frontend naming accordingly)

![Screenshot 2025-06-20 at 4 43 39 PM](https://github.com/user-attachments/assets/9ba345c6-7b67-48db-98ec-dd3093c5b1cd)
![Screenshot 2025-06-20 at 4 44 23 PM](https://github.com/user-attachments/assets/6c2d3d90-0403-4b12-b223-d83889129b77)
![Screenshot 2025-06-20 at 4 44 35 PM](https://github.com/user-attachments/assets/e6dd5b6b-cc3e-42cd-bb81-8465435baeb3)

P.S. Took the "short cut", since as long as the returns have the original fields, it's backward compatible. I did a simple calculation to fix it. Didn't worry about efficiency or anything yet, since probably our goal is to ship the feature ASAP?

