### PR TITLE
Bug Fix: getStats 500 Error (Fixes #112)

### DIFF
--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -18,7 +18,6 @@ VALID_QUERY_INCIDENT_TYPES = VALID_INCIDENT_TYPES | {"", "both"}
 def get_query_cache_key(*args, **kwargs):
     # Convert args to a list for modification
     args_list = list(args)
-    print(args_list)
     # Check if we have a cursor parameter (index 6)
     if len(args_list) > 6 and isinstance(args_list[6], dict):
         cursor = args_list[6]
@@ -323,8 +322,8 @@ def getStats(start: datetime, end: datetime, state="", type="", self_report_stat
     has_next = True
     all_incidents = []
     while has_next:
-        # The page size may need to change when incidents getting more
-        result = queryIncidents(start, end, state, type, self_report_status, 1000, current_cursor)
+        # The page size setting are open to discussion
+        result = queryIncidents(start, end, state, type, self_report_status, 1200, current_cursor)
         # Check if we got an error response
         if isinstance(result, dict) and "error" in result:
             return []

--- a/firestore/incidents.py
+++ b/firestore/incidents.py
@@ -18,7 +18,7 @@ VALID_QUERY_INCIDENT_TYPES = VALID_INCIDENT_TYPES | {"", "both"}
 def get_query_cache_key(*args, **kwargs):
     # Convert args to a list for modification
     args_list = list(args)
-    
+    print(args_list)
     # Check if we have a cursor parameter (index 6)
     if len(args_list) > 6 and isinstance(args_list[6], dict):
         cursor = args_list[6]
@@ -317,13 +317,28 @@ def insertIncident(incident, to_flush_cache=True):
 @cached(cache=INCIDENT_STATS_CACHE)
 def getStats(start: datetime, end: datetime, state="", type="", self_report_status=""):
     stats = {}  # (date, state) : {"news": count, "self_report": count}
-    incidents = queryIncidents(start, end, state, type, self_report_status)
+    # getStats needs to get all incidents at once, so it needs to pagimate through
+    # all results using cursors until all incidents are fetched
+    current_cursor = None
+    has_next = True
+    all_incidents = []
+    while has_next:
+        # The page size may need to change when incidents getting more
+        result = queryIncidents(start, end, state, type, self_report_status, 1000, current_cursor)
+        # Check if we got an error response
+        if isinstance(result, dict) and "error" in result:
+            return []
+        # Extract incidents from the response
+        incidents = result["incidents"]
+        all_incidents.extend(incidents)
+        has_next = result["pagination"]["has_next"]
+        if has_next:
+            next_cursor = result["pagination"]["next_cursor"]["id"]
+            current_cursor = {
+                'id': next_cursor
+            }
 
-    # Check if we got an error response
-    if isinstance(incidents, dict) and "error" in incidents:
-        return []
-
-    for incident in incidents:
+    for incident in all_incidents:
         # Handle both string and datetime inputs
         incident_time = incident["incident_time"]
         if isinstance(incident_time, str):


### PR DESCRIPTION
### Issue ###
After pagination was added, queryIncidents started returning a dict with {"incidents": [...], "pagination": {...}}, but getStats was still treating the result as a list. This caused a 500 error, resulting a network error in frontend, as shown in #112. 

**getStats 500 before fix**
![image](https://github.com/user-attachments/assets/50e4a47f-9140-440c-ace6-e3c80c51fbc2)

### Fix ### 
Extract incidents from the response.

### Improvement ### 
The old getStats() implementation only retrieved 10 incidents per call (default page_size=10), but getStats should retrieve all within date range to render total incidents, chart, map and table.
Now, getStats() uses cursor-based pagination to fetch all incidents in one call by looping through paginates, instead of being limited to one page (10 items before).

### Test ###
**Basic cases**
- No filters: returns all available
- Only time range: returns within time window
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/fe82c4ef-4239-4962-bd97-d3519acf5f8c" />
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/b970aeb3-4af7-4b96-b109-90c80953b1ba" />
<br><br>

**Filter combinations**
- Time range + type=news
- Time range + type=self-report
- Full filter: time range + state + both types + self-report status=approved
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/48a03add-419a-4cb6-8746-7ab9827f2df0" />
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/e34b0efb-6e29-46a9-9f30-c7b3110d0b6d" />
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/7f6f5c4b-cd8b-459a-86bf-1d923be7ea2a" />

**Frontend render correctly**
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/52dbe2d2-b0ba-46be-9f1e-387c55002b65" />


>  Note:
> When testing with the `incident-refined` collection (which includes self-reported incidents), only 2 items were returned in the first call. This is likely due to many self-reports being filtered out by `self_report_status`.
> In contrast, the `incident` collection (used in production) returns up to 10 per call, as most incidents are of type "news" with fewer filters.
> While this may not be an issue now, it's worth noting that as more self-report statuses are introduced, filtering could significantly reduce the number of returned results.