### PR TITLE
Fix issue that translation API call failed with permission error 

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -1,11 +1,31 @@
 from firestore.incidents import (insertIncident)
 from google.cloud import translate
+import google.auth
+
+def get_current_project_id_auth():
+    """
+    Returns the Project ID inferred from the environment using google-auth.
+    This works across App Engine, Cloud Functions, and Cloud Run.
+    """
+    try:
+        # This function looks up the default credentials and project ID
+        # based on the environment where the code is executing.
+        credentials, project_id = google.auth.default()
+        
+        return project_id
+    except Exception as e:
+        # This usually occurs if running locally without proper authentication 
+        # (e.g., no GOOGLE_APPLICATION_CREDENTIALS set).
+        print(f"Error determining Project ID: {e}")
+        return None
 
 translate_api_client = translate.TranslationServiceClient()
 LOCATION = "global"
-PROJECT_ID='hate-crime-tracker'
+PROJECT_ID= get_current_project_id_auth()  #'hate-crime-tracker'
 PARENT = f"projects/{PROJECT_ID}/locations/{LOCATION}"
 BATCH_SIZE=50
+
+print("Current project id:", PROJECT_ID)
 
 def translate_batch(batch, target_lang):
     if len(batch) == 0:


### PR DESCRIPTION
To replicate the error:
1. Start local hatecrimetracker backend
2. Start a local front-end connecting to the backend
3. Load incident using an old date and non-English language
4. Backend will fail with the following error:
```
Traceback (most recent call last):
  File "/Users/lima/dev/tracker/hatecrimetracker/env/lib/python3.13/site-packages/google/api_core/grpc_helpers.py", line 65, in error_remapped_callable
    return callable_(*args, **kwargs)
  File "/Users/lima/dev/tracker/hatecrimetracker/env/lib/python3.13/site-packages/grpc/_channel.py", line 1166, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/Users/lima/dev/tracker/hatecrimetracker/env/lib/python3.13/site-packages/grpc/_channel.py", line 996, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.PERMISSION_DENIED
        details = "Cloud IAM permission 'cloudtranslate.generalModels.predict' denied. "
        debug_error_string = "UNKNOWN:Error received from peer ipv6:%5B2607:f8b0:4006:808::200a%5D:443 {grpc_status:7, grpc_message:"Cloud IAM permission \'cloudtranslate.generalModels.predict\' denied. "}"
```

The issue was the local key refers to hate-crime-tracker-dev project, but the translation code hard-coded to hate-crime-tracker.

The fix it to dynamically get the project id using auth API.
