### PR TITLE
Update runtime to Python 3.12

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 service: default
-runtime: python38
+runtime: python312
 
 env_variables:
   GAE_USE_SOCKETS_HTTPLIB : 'true'


### PR DESCRIPTION
## Summary
- Bumps the Cloud Function runtime to Python 3.12.

Cherry-picked cleanly from \`aa13af1\` onto \`upstream/feature/self-report\` — independent of the other in-flight PRs.

## Test plan
- [ ] Deploy succeeds on Python 3.12
- [ ] Existing endpoints work after deploy